### PR TITLE
Fix Command compatibility with Django>= 1.8

### DIFF
--- a/src/dynamic_fixtures/management/commands/load_dynamic_fixtures.py
+++ b/src/dynamic_fixtures/management/commands/load_dynamic_fixtures.py
@@ -8,9 +8,20 @@ class Command(BaseCommand):
     help_text = 'Load fixtures while keeping dependencies in mind.'
     args = '[app_label] [fixture_name]'
 
+    def add_arguments(self, parser):
+        parser.add_argument('app_label', type=str)
+        parser.add_argument('fixture_name', default=None, nargs='?', type=str)
+
     def handle(self, *args, **options):
         runner = LoadFixtureRunner()
         nodes = None
+
+        if len(args) == 0:
+            if options['fixture_name'] is None:
+                args = (options['app_label'], )
+            else:
+                args = (options['app_label'], options['fixture_name'])
+
         if len(args) == 1:
             nodes = runner.get_app_nodes(app_label=args[0])
         elif len(args) == 2:


### PR DESCRIPTION
This app currently does not work with any Django>=1.8.
The BaseCommand behavior changed, as mentioned [here](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/), so arguments doesn't get parsed correctly.

> Changed in Django 1.8:
> Before Django 1.8, management commands were based on the optparse module, and positional arguments were passed in *args while optional arguments were passed in **options. Now that management commands use argparse for argument parsing, all arguments are passed in **options by default, unless you name your positional arguments to args (compatibility mode). You are encouraged to exclusively use **options for new commands.

So I made this little pull request with Django-1.7 compatibility in mind.
 