### PR TITLE
+  $ ./manage.py list_dynamic_fixtures

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,17 @@ free to setup your fixture data in a way you like::
        def load(self):
            Author.objects.create(name="John Doe")
 
+.. _list_fixtures:
+
+List fixtures
+=============
+
+To list all existing fixtures you can call the management command `list_dynamic_fixtures`::
+
+  $ ./manage.py list_dynamic_fixtures
+
+The output may help to find out the reason why a fixture wasn't loaded.
+
 .. _load_fixtures:
 
 Load fixtures

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ test = pytest
 
 [bumpversion:file:docs/source/conf.py]
 
+[flake8]
+ignore = W601
+max-line-length = 119

--- a/src/dynamic_fixtures/fixtures/runner.py
+++ b/src/dynamic_fixtures/fixtures/runner.py
@@ -56,7 +56,7 @@ class LoadFixtureRunner(object):
         app_nodes = self.get_app_nodes(app_label=app_label)
         nodes = [
             node for node in app_nodes if node[1].startswith(fixture_prefix)
-            ]
+        ]
 
         if len(nodes) > 1:
             raise MultipleFixturesFound(

--- a/src/dynamic_fixtures/management/commands/list_dynamic_fixtures.py
+++ b/src/dynamic_fixtures/management/commands/list_dynamic_fixtures.py
@@ -1,0 +1,85 @@
+from importlib import import_module
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+
+from dynamic_fixtures.fixtures.loader import Loader as OriginLoader
+from dynamic_fixtures.fixtures.runner import LoadFixtureRunner as OriginLoadFixtureRunner
+
+
+class Loader(OriginLoader):
+    def load_disk(self):
+
+        self.disk_fixtures = {}
+
+        app_count = 0
+        for app_config in apps.get_app_configs():
+            app_count += 1
+            if app_config.models_module is None:
+                print("Skip %s because it has no models" % app_config)
+                continue
+
+            self.handle_app_config(app_config=app_config)
+
+        print("\nSearched %i apps." % app_count)
+
+    def handle_app_config(self, app_config):
+
+        # Get the fixtures module directory
+        module_name = self.fixtures_module(app_config.label)
+
+        directory = self.get_module_directory(module_name=module_name)
+
+        if directory is None:
+            return
+
+        fixture_names = self.get_fixture_files(directory=directory)
+
+        # Load them
+        for fixture_name in fixture_names:
+            fixture_module_name="%s.%s" % (module_name, fixture_name)
+            try:
+                fixture_module = import_module(fixture_module_name)
+            except Exception as err:
+                print("Error with fixture %s: %s" % (fixture_module_name, err))
+                continue
+
+            if not hasattr(fixture_module, "Fixture"):
+                print("Fixture %s in app %s has no Fixture class, skip." % (fixture_name, app_config.label))
+                continue
+
+            self.disk_fixtures[app_config.label, fixture_name] = fixture_module.Fixture(fixture_name, app_config.label)
+
+
+class LoadFixtureRunner(OriginLoadFixtureRunner):
+    def __init__(self):
+        self.loader = Loader()
+        self.loader.load_disk()
+        self._graph = None
+
+
+class Command(BaseCommand):
+
+    help_text = 'List all dynamic fixtures.'
+
+    def handle(self, *args, **options):
+        print()
+        print("_"*79)
+        print("Discovery all dynamic fixtures...\n")
+
+        runner = LoadFixtureRunner()
+
+        plan = runner.graph.resolve_node()
+
+        print()
+        print("_"*79)
+        print("All found dynamic fixtures which would be processed in that order:\n")
+
+        fixtures_count = 0
+        for node in plan:
+            print(" * %-25s" % node[1], end=" ", flush=True)
+            obj = runner.loader.disk_fixtures[node]
+            print(obj)
+            fixtures_count += 1
+
+        print("\nFound %i dynamic fixtures." % fixtures_count)

--- a/src/dynamic_fixtures/management/commands/list_dynamic_fixtures.py
+++ b/src/dynamic_fixtures/management/commands/list_dynamic_fixtures.py
@@ -37,7 +37,7 @@ class Loader(OriginLoader):
 
         # Load them
         for fixture_name in fixture_names:
-            fixture_module_name="%s.%s" % (module_name, fixture_name)
+            fixture_module_name = "%s.%s" % (module_name, fixture_name)
             try:
                 fixture_module = import_module(fixture_module_name)
             except Exception as err:
@@ -64,7 +64,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         print()
-        print("_"*79)
+        print("_" * 79)
         print("Discovery all dynamic fixtures...\n")
 
         runner = LoadFixtureRunner()
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         plan = runner.graph.resolve_node()
 
         print()
-        print("_"*79)
+        print("_" * 79)
         print("All found dynamic fixtures which would be processed in that order:\n")
 
         fixtures_count = 0

--- a/tests/management/commands/test_list_dynamic_fixtures.py
+++ b/tests/management/commands/test_list_dynamic_fixtures.py
@@ -1,0 +1,62 @@
+import mock
+from io import StringIO
+
+from django.test import TestCase, modify_settings
+from django.core.management import call_command
+
+from tests.mixins import MockTestCaseMixin
+
+
+class ManagementCommandLoadDynamicFixturesTestCase(MockTestCaseMixin, TestCase):
+
+    def test_app_one(self):
+        APPS=[
+            "tests.fixtures.loader.apps.app_one",
+        ]
+        with modify_settings(INSTALLED_APPS={"append": APPS}):
+            with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                call_command('list_dynamic_fixtures')
+
+        output = mock_stdout.getvalue()
+        print(output)
+
+        self.assertIn("Searched 8 apps.", output)
+
+        self.assertIn("001_load_some_data", output)
+        self.assertIn("002_load_other_data", output)
+
+        self.assertIn("Found 2 dynamic fixtures", output)
+
+    def test_app_wrong_fixture_class(self):
+        APPS=[
+            "tests.fixtures.loader.apps.app_wrong_fixture_class",
+        ]
+        with modify_settings(INSTALLED_APPS={"append": APPS}):
+            with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                call_command('list_dynamic_fixtures')
+
+        output = mock_stdout.getvalue()
+        print(output)
+
+        self.assertIn("Fixture 003_wrong_fixture_class in app app_wrong_fixture_class has no Fixture class, skip.", output)
+
+        self.assertIn("Searched 8 apps.", output)
+
+        self.assertIn("Found 0 dynamic fixtures", output)
+
+    def test_app_broken_fixture_class(self):
+        APPS=[
+            "tests.fixtures.loader.apps.app_broken_fixture",
+        ]
+        with modify_settings(INSTALLED_APPS={"append": APPS}):
+            with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                call_command('list_dynamic_fixtures')
+
+        output = mock_stdout.getvalue()
+        print(output)
+
+        self.assertIn("Fixture 003_empty_fixture in app app_broken_fixture has no Fixture class, skip.", output)
+
+        self.assertIn("Searched 8 apps.", output)
+
+        self.assertIn("Found 0 dynamic fixtures", output)


### PR DESCRIPTION
I have made a django manage command to list all dynamic fixtures and the more important thing: To list every "skipped" fixtures.

e.g.: I didn't know that all apps skipped that has no "models.py" That was the reason to implement this ;)

A example output can be found here: https://gist.github.com/jedie/ac4370ff08a94a99082bea49d7715d17 
